### PR TITLE
fixed warning on x64

### DIFF
--- a/src/aho_corasick/aho_corasick.hpp
+++ b/src/aho_corasick/aho_corasick.hpp
@@ -116,11 +116,11 @@ namespace aho_corasick {
 			}
 
 			size_t determine_median(const interval_collection& intervals) const {
-				int start = -1;
-				int end = -1;
+				size_t start = -1;
+				size_t end = -1;
 				for (const auto& i : intervals) {
-					int cur_start = i.get_start();
-					int cur_end = i.get_end();
+					size_t cur_start = i.get_start();
+					size_t cur_end = i.get_end();
 					if (start == -1 || cur_start < start) {
 						start = cur_start;
 					}


### PR DESCRIPTION
Fixes two narrowing conversions: `int cur_start = size_t(i.get_start())`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/blockchaindev/aho_corasick/8)

<!-- Reviewable:end -->
