### PR TITLE
Improve benchmark

### DIFF
--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -52,7 +52,7 @@ size_t bench_naive(vector<string> text_strings, vector<string> patterns) {
 		for (auto& pattern : patterns) {
 			size_t pos = text.find(pattern);
 			while (pos != text.npos) {
-				pos = text.find(pattern, pos);
+				pos = text.find(pattern, pos + 1);
 				count++;
 			}
 		}

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -34,9 +34,9 @@ using namespace std;
 
 string gen_str(size_t len) {
 	static const char alphanum[] =
-			"0123456789"
-			"!@#$%^&*"
-			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+//			"0123456789"
+//			"!@#$%^&*"
+//			"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			"abcdefghijklmnopqrstuvwxyz";
 
 	string str;
@@ -46,35 +46,34 @@ string gen_str(size_t len) {
 	return string(str);
 }
 
-size_t bench_naive(vector<string> text_strings, vector<string> patterns) {
+size_t bench_naive(string text, vector<string> patterns) {
 	size_t count = 0;
-	for (auto& text : text_strings) {
-		for (auto& pattern : patterns) {
-			size_t pos = text.find(pattern);
-			while (pos != text.npos) {
-				pos = text.find(pattern, pos + 1);
-				count++;
-			}
+	for (auto& pattern : patterns) {
+		size_t pos = text.find(pattern);
+		while (pos != text.npos) {
+			pos = text.find(pattern, pos + 1);
+			count++;
 		}
 	}
 	return count;
 }
 
-size_t bench_aho_corasick(vector<string> text_strings, trie& t) {
+size_t bench_aho_corasick(string text, trie& t) {
 	size_t count = 0;
-	for (auto& text : text_strings) {
-		auto matches = t.parse_text(text);
-		count += matches.size();
-	}
+	auto matches = t.parse_text(text);
+	count += matches.size();
 	return count;
 }
 
 int main(int argc, char** argv) {
+	size_t max_sentences = 10;
+	size_t max_patterns = 1000000;
+
 	cout << "*** Aho-Corasick Benchmark ***" << endl;
 
 	cout << "Generating input text ...";
 	set<string> input_strings;
-	while (input_strings.size() < 10) {
+	while (input_strings.size() < max_sentences) {
 		input_strings.insert(gen_str(256));
 	}
 	vector<string> input_vector(input_strings.begin(), input_strings.end());
@@ -82,8 +81,8 @@ int main(int argc, char** argv) {
 
 	cout << "Generating search patterns ...";
 	set<string> patterns;
-	while (patterns.size() < 1000000) {
-		patterns.insert(gen_str(8));
+	while (patterns.size() < max_patterns) {
+		patterns.insert(gen_str(6));
 	}
 	vector<string> pattern_vector(patterns.begin(), patterns.end());
 	cout << " done" << endl;
@@ -95,18 +94,21 @@ int main(int argc, char** argv) {
 	}
 	cout << " done" << endl;
 
-	map<size_t, tuple<chrono::high_resolution_clock::duration, chrono::high_resolution_clock::duration>> timings;
+	map<size_t, tuple<
+			chrono::high_resolution_clock::duration,
+			chrono::high_resolution_clock::duration,
+			size_t>> timings;
 
 	cout << "Running ";
-	for (size_t i = 10; i > 0; --i) {
+	for (size_t i = 0; i < max_sentences; i++) {
 		cout << ".";
 		auto start_time = chrono::high_resolution_clock::now();
-		size_t count_1 = bench_naive(input_vector, pattern_vector);
+		size_t count_1 = bench_naive(input_vector[i], pattern_vector);
 		auto end_time = chrono::high_resolution_clock::now();
 		auto time_1 = end_time - start_time;
 
 		start_time = chrono::high_resolution_clock::now();
-		size_t count_2 = bench_aho_corasick(input_vector, t);
+		size_t count_2 = bench_aho_corasick(input_vector[i], t);
 		end_time = chrono::high_resolution_clock::now();
 		auto time_2 = end_time - start_time;
 
@@ -114,13 +116,14 @@ int main(int argc, char** argv) {
 			cout << "failed" << endl;
 		}
 
-		timings[i] = make_tuple(time_1, time_2);
+		timings[i] = make_tuple(time_1, time_2, count_1 & count_2);
 	}
 	cout << " done" << endl;
 
 	cout << "Results: " << endl;
 	for (auto& i : timings) {
-		cout << "  loop #" << i.first;
+		cout << "  sentence #" << i.first + 1;
+		cout << ", matched: " << get<2>(i.second) << "/" << max_patterns;
 		cout << ", naive: " << chrono::duration_cast<chrono::milliseconds>(get<0>(i.second)).count();
 		cout << "ms, ac: " << chrono::duration_cast<chrono::milliseconds>(get<1>(i.second)).count() << "ms";
 		cout << endl;


### PR DESCRIPTION
- Fix benchmark bug that `bench_naive` falls into an infinite loop when pattern has matched.
- Print out pattern matching count.
- Reduce pattern length to increase matching probability.
