### PR TITLE
Fixed data race in failure state initialization

### DIFF
--- a/src/aho_corasick/aho_corasick.hpp
+++ b/src/aho_corasick/aho_corasick.hpp
@@ -571,7 +571,6 @@ namespace aho_corasick {
 				depth_one_state->set_failure(d_root.get());
 				q.push(depth_one_state);
 			}
-			d_constructed_failure_states = true;
 
 			while (!q.empty()) {
 				auto cur_state = q.front();


### PR DESCRIPTION
A data race was created when multiple threads entered `parse_text` at the
same time and failure state construction was triggered. The first thread
would enter the failure state construction function and begin
construction, setting a completion flag before initialization was
actually complete. Other threads would see the flag in its set state and
skip over the lock, proceeding to use the trie while the failure states
were still being modified by the first thread.

In addition to this race condition, there was also some possible
undefined behaviour introduced by the double-checked locking
implementation. This has been cleaned up a little with C++11 atomics to
make the implementation more portable, if a little slower. See
https://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/
for more information.